### PR TITLE
Improve Keybind System Actions and Settings UI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,7 +100,7 @@ const defaultViewerWindowConfig: ViewerWindowConfig = {
   alwaysOnTop: true,
 };
 
-const defaultSidebarSide: SidebarSide = 'left';
+const defaultSidebarSide: SidebarSide = 'right';
 
 const viewerWindows: Map<ViewerWindowType, BrowserWindow> = new Map();
 const viewerBoundsSaveTimers: Map<ViewerWindowType, ReturnType<typeof setTimeout>> = new Map();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -404,6 +404,10 @@ const allowedEventKeybinds = {
     label: "Toggle Fullscreen",
     unique: true,
   },
+  "close_focus_session": {
+    label: "Close Focus Session",
+    unique: true,
+  },
   "layout_switch": {
     label: "Switch to Layout",
     args: [
@@ -1131,6 +1135,7 @@ function checkKeybinds() {
   const globalOnlyKeybindEvents = [
     "ui.toggle_quest_log",
     "fullscreen_toggle",
+    "close_focus_session",
     "layout_swap",
     "layout_switch",
     "layout_cycle_forward",
@@ -1173,6 +1178,17 @@ function checkKeybinds() {
   })
 }
 
+function closeFocusSessionWindow() {
+  const mode = (sessionWindow as any)?.sessionData?.mode as LaunchMode | undefined;
+  if (mode !== 'focus' && mode !== 'focus_fullscreen') {
+    return;
+  }
+
+  globalShortcut.unregisterAll();
+  sessionWindow?.destroy();
+  sessionWindow = null;
+}
+
 function dispatchKeybindEvent(bind: any) {
   if (bind.event?.startsWith("ui.")) {
     mainWindow?.webContents.send("event.ui_action_fired", {actionId: bind.event});
@@ -1182,6 +1198,9 @@ function dispatchKeybindEvent(bind: any) {
   switch (bind.event) {
     case "fullscreen_toggle":
       mainWindow?.setFullScreen(!mainWindow?.isFullScreen());
+      break;
+    case "close_focus_session":
+      closeFocusSessionWindow();
       break;
     case "layout_swap":
       mainWindow?.webContents.send("event.layout_swap");
@@ -1256,28 +1275,35 @@ function registerSessionKeybinds(mode: LaunchMode) {
 
   // Find fullscreen keybind
   const fullscreenBind = neuzosConfig.keyBinds.find((bind: any) => bind.event === "fullscreen_toggle");
+  const closeFocusSessionBind = neuzosConfig.keyBinds.find((bind: any) => bind.event === "close_focus_session");
 
-  if (!fullscreenBind) {
+  if (!fullscreenBind && !closeFocusSessionBind) {
     return;
   }
 
   try {
+    if ((mode === 'focus' || mode === 'focus_fullscreen') && closeFocusSessionBind?.key) {
+      globalShortcut.register(closeFocusSessionBind.key, () => {
+        closeFocusSessionWindow();
+      });
+    }
+
     switch (mode) {
       case 'session':
         // Allow fullscreen toggle
-        globalShortcut.register(fullscreenBind.key, () => {
+        if (fullscreenBind?.key) globalShortcut.register(fullscreenBind.key, () => {
           sessionWindow?.setFullScreen(!sessionWindow?.isFullScreen());
         });
         break;
       case 'focus':
         // Prevent fullscreen
-        globalShortcut.register(fullscreenBind.key, () => {
+        if (fullscreenBind?.key) globalShortcut.register(fullscreenBind.key, () => {
           // Do nothing - prevent fullscreen
         });
         break;
       case 'focus_fullscreen':
         // Prevent removing fullscreen
-        globalShortcut.register(fullscreenBind.key, () => {
+        if (fullscreenBind?.key) globalShortcut.register(fullscreenBind.key, () => {
           if (!sessionWindow?.isFullScreen()) {
             sessionWindow?.setFullScreen(true);
           }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1128,18 +1128,39 @@ function checkKeybinds() {
     ...Object.keys(allowedUiActionKeybinds),
   ]);
 
+  const globalOnlyKeybindEvents = [
+    "ui.toggle_quest_log",
+    "fullscreen_toggle",
+    "layout_swap",
+    "layout_switch",
+    "layout_cycle_forward",
+    "layout_cycle_backward",
+  ];
+
+  globalOnlyKeybindEvents.forEach((event) => {
+    const profileBind = neuzosConfig.keyBindProfiles
+      .flatMap((profile: any) => profile.keybinds ?? [])
+      .find((bind: any) => bind?.event === event && typeof bind?.key === "string" && bind.key !== "");
+    const hasGlobalBind = neuzosConfig.keyBinds.some((bind: any) => bind?.event === event);
+
+    if (profileBind && !hasGlobalBind) {
+      neuzosConfig.keyBinds.push({
+        key: profileBind.key,
+        event,
+        args: Array.isArray(profileBind.args) ? profileBind.args : undefined,
+      });
+    }
+  });
+
   neuzosConfig.keyBinds = neuzosConfig.keyBinds.filter((bind: any) => {
     return allowedKeybindEvents.has(bind.event);
   })
 
-  const activeProfile = neuzosConfig.keyBindProfiles.find(
-    (profile: any) => profile.id === neuzosConfig.activeKeyBindProfileId
-  );
-  if (activeProfile) {
-    activeProfile.keybinds = activeProfile.keybinds.filter((bind: any) => {
-      return allowedKeybindEvents.has(bind.event);
+  neuzosConfig.keyBindProfiles.forEach((profile: any) => {
+    profile.keybinds = (profile.keybinds ?? []).filter((bind: any) => {
+      return allowedKeybindEvents.has(bind.event) && !globalOnlyKeybindEvents.includes(bind.event);
     });
-  }
+  });
 
   // filter empty keybinds
   neuzosConfig.keyBinds = neuzosConfig.keyBinds.filter((bind) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -72,6 +72,7 @@ const allowedCommandLineSwitches = [
 let mainWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let sessionWindow: BrowserWindow | null = null;
+let lastKeybindToggleAt = 0;
 
 type ViewerWindowType = 'navi_guide' | 'flyffipedia';
 type SidebarSide = 'left' | 'right';
@@ -406,6 +407,10 @@ const allowedEventKeybinds = {
   },
   "close_focus_session": {
     label: "Close Focus Session",
+    unique: true,
+  },
+  "toggle_keybinds": {
+    label: "Enable / Disable Keybinds",
     unique: true,
   },
   "layout_switch": {
@@ -1136,6 +1141,7 @@ function checkKeybinds() {
     "ui.toggle_quest_log",
     "fullscreen_toggle",
     "close_focus_session",
+    "toggle_keybinds",
     "layout_swap",
     "layout_switch",
     "layout_cycle_forward",
@@ -1189,6 +1195,36 @@ function closeFocusSessionWindow() {
   sessionWindow = null;
 }
 
+function setMainWindowShortcutsEnabled(enabled: boolean) {
+  mainWindowShortcutsEnabled = enabled;
+  if (enabled) {
+    registerKeybinds();
+  } else {
+    globalShortcut.unregisterAll();
+    registerKeybindToggleShortcut();
+  }
+  mainWindow?.webContents.send("event.shortcuts_state_changed", enabled);
+}
+
+function registerKeybindToggleShortcut() {
+  const toggleBind = neuzosConfig?.keyBinds?.find((bind: any) => bind.event === "toggle_keybinds");
+  if (!toggleBind?.key) return;
+
+  try {
+    globalShortcut.unregister(toggleBind.key);
+    globalShortcut.register(toggleBind.key, () => {
+      const now = Date.now();
+      if (now - lastKeybindToggleAt < 500) {
+        return;
+      }
+      lastKeybindToggleAt = now;
+      setMainWindowShortcutsEnabled(!mainWindowShortcutsEnabled);
+    });
+  } catch (e) {
+    console.warn("Failed to register keybind toggle shortcut:", toggleBind.key, e);
+  }
+}
+
 function dispatchKeybindEvent(bind: any) {
   if (bind.event?.startsWith("ui.")) {
     mainWindow?.webContents.send("event.ui_action_fired", {actionId: bind.event});
@@ -1201,6 +1237,16 @@ function dispatchKeybindEvent(bind: any) {
       break;
     case "close_focus_session":
       closeFocusSessionWindow();
+      break;
+    case "toggle_keybinds":
+      {
+        const now = Date.now();
+        if (now - lastKeybindToggleAt < 500) {
+          break;
+        }
+        lastKeybindToggleAt = now;
+      }
+      setMainWindowShortcutsEnabled(!mainWindowShortcutsEnabled);
       break;
     case "layout_swap":
       mainWindow?.webContents.send("event.layout_swap");
@@ -1241,6 +1287,7 @@ function registerKeybinds() {
 
   // Only register shortcuts if they are enabled for main window
   if (!mainWindowShortcutsEnabled) {
+    registerKeybindToggleShortcut();
     return;
   }
 
@@ -1562,15 +1609,8 @@ function registerSessionKeybinds(mode: LaunchMode) {
     });
 
     // IPC handlers for global shortcuts toggle
-    ipcMain.on("main_window.toggle_shortcuts", (event, enabled: boolean) => {
-      mainWindowShortcutsEnabled = enabled;
-      const win = BrowserWindow.fromWebContents(event.sender);
-      if (enabled) {
-        registerKeybinds();
-      } else {
-        globalShortcut.unregisterAll();
-      }
-      win?.webContents.send("event.shortcuts_state_changed", enabled);
+    ipcMain.on("main_window.toggle_shortcuts", (_event, enabled: boolean) => {
+      setMainWindowShortcutsEnabled(enabled);
     });
 
     ipcMain.on("keybinds.dispatch", (_, bind: any) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -392,6 +392,14 @@ const allowedEventKeybinds = {
     label: "Swap to Previous Layout",
     unique: true,
   },
+  "layout_cycle_forward": {
+    label: "Cycle Layout Forward",
+    unique: true,
+  },
+  "layout_cycle_backward": {
+    label: "Cycle Layout Backward",
+    unique: true,
+  },
   "fullscreen_toggle": {
     label: "Toggle Fullscreen",
     unique: true,
@@ -1156,6 +1164,12 @@ function dispatchKeybindEvent(bind: any) {
       break;
     case "layout_swap":
       mainWindow?.webContents.send("event.layout_swap");
+      break;
+    case "layout_cycle_forward":
+      mainWindow?.webContents.send("event.layout_cycle_forward");
+      break;
+    case "layout_cycle_backward":
+      mainWindow?.webContents.send("event.layout_cycle_backward");
       break;
     case "layout_switch":
       if (bind.args?.length > 0)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2425,14 +2425,14 @@ function registerSessionKeybinds(mode: LaunchMode) {
     const defaultMainWindowConfig = {
       width: defaultWindowWidth,
       height: defaultWindowHeight,
-      maximized: false,
+      maximized: true,
       zoom: 1.0
     };
 
     const defaultSessionWindowConfig = {
       width: defaultWindowWidth,
       height: defaultWindowHeight,
-      maximized: false,
+      maximized: true,
       zoom: 1.0
     };
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2559,12 +2559,13 @@ function registerSessionKeybinds(mode: LaunchMode) {
     // Merge neuzosConfig with defaults (user config takes precedence)
     neuzosConfig = {...defaultNeuzosConfig, ...neuzosConfig};
 
-    if (neuzosConfig.autoDeleteAllCachesOnStartup) {
-      void Promise.all((neuzosConfig.sessions ?? []).map((sessionConfig: any) => {
-        if (typeof sessionConfig?.id !== 'string') {
-          return Promise.resolve();
-        }
+    const startupCacheClearSessions = (neuzosConfig.sessions ?? []).filter((sessionConfig: any) => {
+      return typeof sessionConfig?.id === 'string' &&
+        (neuzosConfig.autoDeleteAllCachesOnStartup || sessionConfig.autoDeleteCache);
+    });
 
+    if (startupCacheClearSessions.length > 0) {
+      void Promise.all(startupCacheClearSessions.map((sessionConfig: any) => {
         return session.fromPartition(`persist:${sessionConfig.id}`).clearCache().catch((err: any) => {
           console.warn('Startup cache clear failed for session', sessionConfig.id, err);
         });

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -90,7 +90,7 @@
           width: 1200,
           height: 800,
           zoom: 1.0,
-          maximized: false
+          maximized: true
         },
         settings: {
           width: 1200,
@@ -102,7 +102,7 @@
           width: 1024,
           height: 768,
           zoom: 1.0,
-          maximized: false
+          maximized: true
         }
       },
       sessions: [],

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -201,6 +201,31 @@
     }
   })
 
+  const cycleLayout = (direction: 1 | -1) => {
+    const layoutOrder = mainWindowState.tabs.layoutOrder
+    if (layoutOrder.length <= 1) {
+      return
+    }
+
+    const activeLayoutId = mainWindowState.tabs.activeLayoutId
+    const currentIndex = layoutOrder.findIndex(layoutId => layoutId === activeLayoutId)
+    const nextIndex = currentIndex === -1
+      ? 0
+      : (currentIndex + direction + layoutOrder.length) % layoutOrder.length
+    const nextLayoutId = layoutOrder[nextIndex]
+
+    mainWindowState.tabs.previousLayoutId = activeLayoutId
+    mainWindowState.tabs.activeLayoutId = nextLayoutId
+  }
+
+  listen('event.layout_cycle_forward', (_) => {
+    cycleLayout(1)
+  })
+
+  listen('event.layout_cycle_backward', (_) => {
+    cycleLayout(-1)
+  })
+
   listen('event.stop_session', (_, sessionId: string) => {
     console.log("stop_session", sessionId)
     const layouts = Object.values(mainWindowState.sessionsLayoutsRef[sessionId]?.layouts ?? {}) as Array<{ stopClient?: (onStopped?: () => void) => void }>

--- a/src/renderer/src/Settings.svelte
+++ b/src/renderer/src/Settings.svelte
@@ -224,7 +224,7 @@
   };
 
   const autoSave = () => {
-    if (!neuzosConfig.autoSaveSettings || isLoading || isSaving) return;
+    if (!neuzosConfig.autoSaveSettings || activeTab === 'keybinds' || isLoading || isSaving) return;
 
     // Clear existing timeout
     if (autoSaveTimeout) {
@@ -233,7 +233,9 @@
 
     // Debounce auto-save by 500ms
     autoSaveTimeout = setTimeout(() => {
-      saveSettings(false); // Don't show toast for auto-save
+      if (activeTab !== 'keybinds') {
+        saveSettings(false); // Don't show toast for auto-save
+      }
     }, 500);
   };
 
@@ -280,7 +282,7 @@
           </div>
           <div class="flex-1"></div>
           <div class="flex items-center gap-2 px-0.5 py-0.5">
-            {#if !neuzosConfig.autoSaveSettings}
+            {#if !neuzosConfig.autoSaveSettings || activeTab === 'keybinds'}
 
             <Button
               size="xs"

--- a/src/renderer/src/Settings.svelte
+++ b/src/renderer/src/Settings.svelte
@@ -7,6 +7,7 @@
   import SettingsBar from "./components/SettingsWindow/SettingsBar.svelte";
   import KeybindsSettings from "./components/SettingsWindow/Tabs/KeybindsSettings.svelte";
   import * as Tabs from "$lib/components/ui/tabs";
+  import * as Dialog from "$lib/components/ui/dialog";
 
   import LaunchSettings from "./components/SettingsWindow/Tabs/LaunchSettings.svelte";
   import SessionSettings from "./components/SettingsWindow/Tabs/SessionSettings.svelte";
@@ -200,6 +201,11 @@
   let autoSaveTimeout: ReturnType<typeof setTimeout> | null = null;
   let isSaving = $state(false);
   let lastConfigSnapshot = $state("");
+  let unsavedCloseDialogOpen = $state(false);
+
+  const hasUnsavedChanges = () => {
+    return lastConfigSnapshot !== "" && JSON.stringify(neuzosConfig) !== lastConfigSnapshot;
+  };
 
   const saveSettings = async (showToast: boolean = true) => {
     if (isSaving) return;
@@ -252,6 +258,26 @@
     }
   })
 
+  const requestCloseSettings = () => {
+    if (hasUnsavedChanges()) {
+      unsavedCloseDialogOpen = true;
+      return;
+    }
+
+    neuzosBridge.settingsWindow.close();
+  };
+
+  const closeWithoutSaving = () => {
+    unsavedCloseDialogOpen = false;
+    neuzosBridge.settingsWindow.close();
+  };
+
+  const saveAndClose = async () => {
+    await saveSettings();
+    unsavedCloseDialogOpen = false;
+    neuzosBridge.settingsWindow.close();
+  };
+
 
 </script>
 <ModeWatcher/>
@@ -266,7 +292,7 @@
 {:else}
   <SharedEvents/>
   <div class="w-full h-full flex flex-col border-2 ">
-    <SettingsBar/>
+    <SettingsBar onRequestClose={requestCloseSettings}/>
     <div class="flex w-full flex-col gap-6 p-4 flex-1 overflow-hidden">
       <Tabs.Root bind:value={activeTab} class="h-full w-full">
         <Tabs.List class="relative w-full">
@@ -330,4 +356,26 @@
     </div>
 
   </div>
+
+  <Dialog.Root bind:open={unsavedCloseDialogOpen}>
+    <Dialog.Content class="sm:max-w-md">
+      <Dialog.Header>
+        <Dialog.Title>Unsaved Changes</Dialog.Title>
+        <Dialog.Description>
+          You have unsaved settings changes. Save them before closing?
+        </Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer class="gap-2">
+        <Button onclick={saveAndClose} disabled={isSaving}>
+          Save and Close
+        </Button>
+        <Button variant="outline" onclick={closeWithoutSaving}>
+          Close without Saving
+        </Button>
+        <Button variant="ghost" onclick={() => unsavedCloseDialogOpen = false}>
+          Cancel
+        </Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Root>
 {/if}

--- a/src/renderer/src/components/MainWindow/MainBar.svelte
+++ b/src/renderer/src/components/MainWindow/MainBar.svelte
@@ -25,6 +25,7 @@
     ZoomIn,
     ZoomOut,
     RotateCcw,
+    BookMarked,
     BookOpen,
     Globe
   } from '@lucide/svelte'
@@ -562,7 +563,7 @@
     <BookOpen class="size-3.5"/>
   </Button>
   <Button size="icon-xs" variant="outline" onclick={openFlyffipedia} class="cursor-pointer" title="Open Flyffipedia">
-    <Globe class="size-3.5"/>
+    <BookMarked class="size-3.5"/>
   </Button>
 
   <Button

--- a/src/renderer/src/components/MainWindow/MainBar.svelte
+++ b/src/renderer/src/components/MainWindow/MainBar.svelte
@@ -16,6 +16,7 @@
     Home,
     ChevronLeft,
     ChevronRight,
+    ChevronDown,
     RefreshCw,
     Fullscreen,
     Keyboard,
@@ -28,7 +29,7 @@
     Globe
   } from '@lucide/svelte'
   import {getContext, onMount} from "svelte";
-  import type {MainWindowState, NeuzSession} from "$lib/types";
+  import type {MainWindowState, NeuzSession, NeuzSessionGroup} from "$lib/types";
   import * as Dialog from '$lib/components/ui/dialog'
   import * as ContextMenu from '$lib/components/ui/context-menu'
   import * as Tabs from '$lib/components/ui/tabs'
@@ -46,6 +47,7 @@
   import {ScrollText} from '@lucide/svelte';
 
   let shortcutsEnabled = $state(true);
+  let collapsedSessionGroupIds: Record<string, boolean> = $state({});
 
   onMount(async () => {
     try {
@@ -200,7 +202,74 @@
     electronApi.send("session_launcher.launch_session", sessionId, mode);
   }
 
+  function getLaunchableSessions(): NeuzSession[] {
+    return mainWindowState.sessions.filter(session => session.partitionOverwrite !== 'browser');
+  }
+
+  function getSessionGroups(): NeuzSessionGroup[] {
+    return mainWindowState.config.sessionGroups ?? [];
+  }
+
+  function getGroupSessions(group: NeuzSessionGroup): NeuzSession[] {
+    const sessionMap = new Map(getLaunchableSessions().map((session) => [session.id, session]));
+    const sessionIds = Array.isArray(group.sessionIds) ? group.sessionIds : [];
+    return sessionIds
+      .map((sessionId) => sessionMap.get(sessionId))
+      .filter((session): session is NeuzSession => session !== undefined);
+  }
+
+  function getUngroupedSessions(): NeuzSession[] {
+    const groupedSessionIds = new Set(getSessionGroups().flatMap((group) => Array.isArray(group.sessionIds) ? group.sessionIds : []));
+    return getLaunchableSessions().filter((session) => !groupedSessionIds.has(session.id));
+  }
+
+  function isSessionGroupCollapsed(groupId: string): boolean {
+    return collapsedSessionGroupIds[groupId] ?? false;
+  }
+
+  function toggleSessionGroupCollapsed(groupId: string) {
+    collapsedSessionGroupIds[groupId] = !isSessionGroupCollapsed(groupId);
+  }
+
 </script>
+{#snippet sessionLaunchCard(sessionTab)}
+  <Card.Root class="gap-2 pt-2 pb-3">
+    <Card.Header class="py-0">
+      <div class="flex items-center gap-2">
+        <img src={getIconPath(sessionTab)} alt={sessionTab.label} class="w-4 h-4"/>
+        <span>{sessionTab.label}</span>
+      </div>
+    </Card.Header>
+    <Card.Content class="py-0">
+      <div class="flex gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          class="text-xs h-7 flex-1"
+          onclick={() => launchSession(sessionTab.id, 'session')}
+        >
+          Normal
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="text-xs h-7 flex-1"
+          onclick={() => launchSession(sessionTab.id, 'focus')}
+        >
+          Focus
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="text-xs h-7 flex-1"
+          onclick={() => launchSession(sessionTab.id, 'focus_fullscreen')}
+        >
+          Focus Fullscreen
+        </Button>
+      </div>
+    </Card.Content>
+  </Card.Root>
+{/snippet}
 <div
   id="titlebar"
   class="gap-2 p-1 px-2 select-none border-b border-accent flex items-center justify-end bg-accent/50 min-h-10"
@@ -249,49 +318,52 @@
             </div>
           </Tabs.Content>
           <Tabs.Content value="sessions">
-            <div class="grid gap-4 grid-cols-1 w-full h-full max-h-[33vh] overflow-y-auto px-6">
-              {#each mainWindowState.sessions as sessionTab (sessionTab.id)}
-                {@const isBrowser = sessionTab.partitionOverwrite === 'browser'}
-                {#if !isBrowser}
-                  <Card.Root class="gap-2 pt-2 pb-3">
-                    <Card.Header class="py-0">
-                      <div class="flex items-center gap-2">
-                        <img src={getIconPath(sessionTab)} alt={sessionTab.label} class="w-4 h-4"/>
-                        <span>{sessionTab.label}</span>
+            <div class="flex flex-col gap-3 w-full h-full max-h-[33vh] overflow-y-auto px-6">
+              {#each getSessionGroups() as group (group.id)}
+                {@const groupSessions = getGroupSessions(group)}
+                {#if groupSessions.length > 0}
+                  <div class="space-y-2">
+                    <button
+                      type="button"
+                      class="flex w-full items-center justify-between gap-2 rounded-sm px-1 py-0.5 text-left text-xs text-muted-foreground hover:bg-muted/60"
+                      onclick={() => toggleSessionGroupCollapsed(group.id)}
+                    >
+                      <div class="flex min-w-0 items-center gap-1.5">
+                        <ChevronDown class={`size-3 shrink-0 transition-transform ${isSessionGroupCollapsed(group.id) ? 'rotate-180' : ''}`}/>
+                        <span class="truncate font-semibold text-foreground">{group.label}</span>
                       </div>
-                    </Card.Header>
-                    <Card.Content class="py-0">
-                      <div class="flex gap-1.5">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          class="text-xs h-7 flex-1"
-                          onclick={() => launchSession(sessionTab.id, 'session')}
-                        >
-                          Normal
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          class="text-xs h-7 flex-1"
-                          onclick={() => launchSession(sessionTab.id, 'focus')}
-                        >
-                          Focus
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          class="text-xs h-7 flex-1"
-                          onclick={() => launchSession(sessionTab.id, 'focus_fullscreen')}
-                        >
-                          Focus Fullscreen
-                        </Button>
+                      <span class="shrink-0">{groupSessions.length}</span>
+                    </button>
+                    {#if !isSessionGroupCollapsed(group.id)}
+                      <div class="grid gap-2">
+                        {#each groupSessions as sessionTab (sessionTab.id)}
+                          {@render sessionLaunchCard(sessionTab)}
+                        {/each}
                       </div>
-                    </Card.Content>
-                  </Card.Root>
+                    {/if}
+                  </div>
                 {/if}
               {/each}
 
+              {#if getUngroupedSessions().length > 0}
+                <div class="space-y-2">
+                  {#if getSessionGroups().length > 0}
+                    <div class="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                      <span class="font-semibold text-foreground">Ungrouped</span>
+                      <span>{getUngroupedSessions().length}</span>
+                    </div>
+                  {/if}
+                  <div class="grid gap-2">
+                    {#each getUngroupedSessions() as sessionTab (sessionTab.id)}
+                      {@render sessionLaunchCard(sessionTab)}
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+
+              {#if getLaunchableSessions().length === 0}
+                <p class="text-center text-sm text-muted-foreground">No sessions available</p>
+              {/if}
             </div>
           </Tabs.Content>
         </Tabs.Root>

--- a/src/renderer/src/components/MainWindow/MainBar.svelte
+++ b/src/renderer/src/components/MainWindow/MainBar.svelte
@@ -27,7 +27,8 @@
     RotateCcw,
     BookMarked,
     BookOpen,
-    Globe
+    Globe,
+    RadioTower
   } from '@lucide/svelte'
   import {getContext, onMount} from "svelte";
   import type {MainWindowState, NeuzSession, NeuzSessionGroup} from "$lib/types";
@@ -190,6 +191,23 @@
       Object.values(layouts).forEach((ref: any) => ref.setZoom?.(clamped))
     }
     void neuzosBridge.sessions.setZoom(sessionId, clamped)
+  }
+
+  const isActiveReceiver = (sessionId: string) => {
+    return mainWindowState.config.syncReceiverSessionId === sessionId
+  }
+
+  const toggleActiveReceiver = (sessionId: string) => {
+    const nextReceiverId = isActiveReceiver(sessionId) ? null : sessionId
+    mainWindowState.config.syncReceiverSessionId = nextReceiverId
+    neuzosBridge.sessions.setSyncReceiver(nextReceiverId)
+  }
+
+  const layoutHasActiveReceiver = (layout: { rows?: { sessionIds?: string[] }[] }) => {
+    const receiverId = mainWindowState.config.syncReceiverSessionId
+    if (!receiverId) return false
+
+    return layout.rows?.some((row) => row.sessionIds?.includes(receiverId)) ?? false
   }
 
 
@@ -388,6 +406,9 @@
                   onclick={() => switchToLayout(layoutId)}>
             <img src="icons/{layTab.icon.slug}.png" alt={layTab.icon.slug} class="w-4 h-4"/>
             {layTab.label}
+            {#if layoutHasActiveReceiver(layTab)}
+              <RadioTower class="h-3.5 w-3.5 text-primary" />
+            {/if}
           </Button>
         </ContextMenu.Trigger>
         <ContextMenu.Content>
@@ -512,14 +533,6 @@
                   </ContextMenu.Item>
                   <ContextMenu.Separator/>
                   <ContextMenu.Item
-                    onclick={() => setSessionZoom(sessionId, getSessionZoom(sessionId) - 0.05)}
-                    disabled={getSessionZoom(sessionId) <= 0.5}>
-                    <div class="flex items-center gap-2">
-                      <ZoomOut class="h-4"/>
-                      Zoom Out
-                    </div>
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
                     onclick={() => setSessionZoom(sessionId, getSessionZoom(sessionId) + 0.05)}
                     disabled={getSessionZoom(sessionId) >= 1.5}>
                     <div class="flex items-center gap-2">
@@ -528,11 +541,31 @@
                     </div>
                   </ContextMenu.Item>
                   <ContextMenu.Item
+                    onclick={() => setSessionZoom(sessionId, getSessionZoom(sessionId) - 0.05)}
+                    disabled={getSessionZoom(sessionId) <= 0.5}>
+                    <div class="flex items-center gap-2">
+                      <ZoomOut class="h-4"/>
+                      Zoom Out
+                    </div>
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
                     onclick={() => setSessionZoom(sessionId, 1.0)}
                     disabled={getSessionZoom(sessionId) === 1.0}>
                     <div class="flex items-center gap-2">
                       <RotateCcw class="h-4"/>
                       Reset Zoom ({(getSessionZoom(sessionId) * 100).toFixed(0)}%)
+                    </div>
+                  </ContextMenu.Item>
+                  <ContextMenu.Separator/>
+                  <ContextMenu.Item onclick={() => toggleActiveReceiver(sessionId)}>
+                    <div class="flex w-full items-center justify-between gap-4">
+                      <div class="flex items-center gap-2">
+                        <RadioTower class="h-4"/>
+                        Active Receiver
+                      </div>
+                      {#if isActiveReceiver(sessionId)}
+                        <Check class="h-4"/>
+                      {/if}
                     </div>
                   </ContextMenu.Item>
                 </ContextMenu.SubContent>

--- a/src/renderer/src/components/MainWindow/MainBarComponents/PinnedActions.svelte
+++ b/src/renderer/src/components/MainWindow/MainBarComponents/PinnedActions.svelte
@@ -261,6 +261,15 @@
 </script>
 
 <!-- Pinned Actions -->
+{#if pinnedActionsToShow.length > 0}
+  <div
+    class="flex size-7 shrink-0 items-center justify-center rounded-md bg-accent/30 text-muted-foreground"
+    title="Action Pins"
+  >
+    <Swords class="size-4"/>
+  </div>
+{/if}
+
 {#each pinnedActionsToShow as sessionPinned, sessionIndex (sessionPinned.sessionId)}
   {#if sessionIndex > 0}
     <Separator orientation="vertical" class="h-4"/>

--- a/src/renderer/src/components/MainWindow/MainSectionsContainer.svelte
+++ b/src/renderer/src/components/MainWindow/MainSectionsContainer.svelte
@@ -8,7 +8,7 @@
   const questPanel = getQuestPanelContext();
 </script>
 
-<div class="flex flex-1 p-4 relative {questPanel.sidebarSide === 'right' ? 'flex-row-reverse' : ''}">
+<div class="flex flex-1 min-h-0 overflow-hidden p-4 relative {questPanel.sidebarSide === 'right' ? 'flex-row-reverse' : ''}">
   <FloatingWindowsPortal>
     <WidgetsManager/>
   </FloatingWindowsPortal>

--- a/src/renderer/src/components/QuestLog/QuestPanel.svelte
+++ b/src/renderer/src/components/QuestLog/QuestPanel.svelte
@@ -145,8 +145,8 @@
 </script>
 
 <div
-  class="flex flex-col h-full w-80 border-border/60 bg-background absolute top-0 bottom-0 z-40 shadow-lg {questPanel.sidebarSide === 'right' ? 'left-0 right-auto border-r border-l-0' : 'right-0 left-auto border-l border-r-0'}"
-  transition:fly={{ x: questPanel.sidebarSide === 'right' ? -320 : 320, duration: 250, easing: cubicOut }}
+  class="flex flex-col h-full w-80 border-border/60 bg-background absolute top-0 bottom-0 z-40 shadow-lg {questPanel.sidebarSide === 'right' ? 'right-0 left-auto border-l border-r-0' : 'left-0 right-auto border-r border-l-0'}"
+  transition:fly={{ x: questPanel.sidebarSide === 'right' ? 320 : -320, duration: 250, easing: cubicOut }}
 >
   <!-- TODO Checklist (character-specific) -->
   <TodoChecklist />

--- a/src/renderer/src/components/SettingsWindow/SettingsBar.svelte
+++ b/src/renderer/src/components/SettingsWindow/SettingsBar.svelte
@@ -5,6 +5,14 @@
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
   import { getNeuzosBridgeContext } from "$lib/contexts/neuzosBridgeContext";
 
+  type Props = {
+    onRequestClose?: () => void;
+  };
+
+  let {
+    onRequestClose
+  }: Props = $props();
+
   const neuzosBridge = getNeuzosBridgeContext()
 </script>
 <div
@@ -65,7 +73,11 @@
   <Button
     variant="outline"
     onclick={() => {
-         neuzosBridge.settingsWindow.close()
+         if (onRequestClose) {
+           onRequestClose()
+         } else {
+           neuzosBridge.settingsWindow.close()
+         }
       }}
     size="icon-xs"
     class="cursor-pointer"

--- a/src/renderer/src/components/SettingsWindow/Tabs/GeneralSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/GeneralSettings.svelte
@@ -29,7 +29,7 @@
         width: 1200,
         height: 800,
         zoom: 1.0,
-        maximized: false
+        maximized: true
       },
       settings: {
         width: 1200,
@@ -41,7 +41,7 @@
         width: 1024,
         height: 768,
         zoom: 1.0,
-        maximized: false
+        maximized: true
       }
     };
   }
@@ -50,7 +50,7 @@
       width: 1200,
       height: 800,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
   }
   if (!neuzosConfig.window.settings) {
@@ -66,7 +66,7 @@
       width: 1024,
       height: 768,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
   }
 
@@ -239,25 +239,25 @@
   // Handle main window settings
   function handleMainWindowWidth(value: number) {
     if (!neuzosConfig.window) neuzosConfig.window = {} as NonNullable<NeuzConfig['window']>;
-    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: false};
+    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: true};
     neuzosConfig.window.main.width = value;
   }
 
   function handleMainWindowHeight(value: number) {
     if (!neuzosConfig.window) neuzosConfig.window = {} as NonNullable<NeuzConfig['window']>;
-    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: false};
+    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: true};
     neuzosConfig.window.main.height = value;
   }
 
   function handleMainWindowZoom(value: number) {
     if (!neuzosConfig.window) neuzosConfig.window = {} as NonNullable<NeuzConfig['window']>;
-    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: false};
+    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: true};
     neuzosConfig.window.main.zoom = value;
   }
 
   function handleMainWindowMaximized(enabled: boolean) {
     if (!neuzosConfig.window) neuzosConfig.window = {} as NonNullable<NeuzConfig['window']>;
-    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: false};
+    if (!neuzosConfig.window.main) neuzosConfig.window.main = {width: 1200, height: 800, zoom: 1.0, maximized: true};
     neuzosConfig.window.main.maximized = enabled;
   }
 
@@ -293,7 +293,7 @@
       width: 1024,
       height: 768,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
     neuzosConfig.window.session.width = value;
   }
@@ -304,7 +304,7 @@
       width: 1024,
       height: 768,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
     neuzosConfig.window.session.height = value;
   }
@@ -315,7 +315,7 @@
       width: 1024,
       height: 768,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
     neuzosConfig.window.session.zoom = value;
   }
@@ -326,7 +326,7 @@
       width: 1024,
       height: 768,
       zoom: 1.0,
-      maximized: false
+      maximized: true
     };
     neuzosConfig.window.session.maximized = enabled;
   }

--- a/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
@@ -58,6 +58,7 @@
     'ui.toggle_quest_log',
     'fullscreen_toggle',
     'close_focus_session',
+    'toggle_keybinds',
     'layout_swap',
     'layout_switch',
     'layout_cycle_forward',
@@ -120,6 +121,8 @@
         return 'Toggles Fullscreen Mode.';
       case 'close_focus_session':
         return 'Closes the active Focus Session Window.';
+      case 'toggle_keybinds':
+        return 'Enable or Disable NeuzOS Keybinds.';
       case 'layout_swap':
         return 'Switches between the two last used Layouts.';
       case 'layout_cycle_forward':

--- a/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
@@ -57,6 +57,7 @@
   const systemActionEventIds = [
     'ui.toggle_quest_log',
     'fullscreen_toggle',
+    'close_focus_session',
     'layout_swap',
     'layout_switch',
     'layout_cycle_forward',
@@ -78,7 +79,7 @@
       };
     }
 
-    if (event === 'fullscreen_toggle') {
+    if (event === 'fullscreen_toggle' || event === 'close_focus_session') {
       return {
         label: allowedEventKeybinds[event]?.label ?? event,
         category: 'Window'
@@ -100,7 +101,7 @@
       return 'Layout';
     }
 
-    if (event === 'fullscreen_toggle') {
+    if (event === 'fullscreen_toggle' || event === 'close_focus_session') {
       return 'Window';
     }
 
@@ -117,6 +118,8 @@
         return 'Show / Hide the Quest Log Panel.';
       case 'fullscreen_toggle':
         return 'Toggles Fullscreen Mode.';
+      case 'close_focus_session':
+        return 'Closes the active Focus Session Window.';
       case 'layout_swap':
         return 'Switches between the two last used Layouts.';
       case 'layout_cycle_forward':

--- a/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/KeybindsSettings.svelte
@@ -54,6 +54,130 @@
     [key: string]: { label: string, args?: string[], unique?: boolean }
   } = $state({});
   let uiActions: UIActionDescriptor[] = $state([]);
+  const systemActionEventIds = [
+    'ui.toggle_quest_log',
+    'fullscreen_toggle',
+    'layout_swap',
+    'layout_switch',
+    'layout_cycle_forward',
+    'layout_cycle_backward'
+  ];
+
+  const isSystemActionEvent = (event: string) => systemActionEventIds.includes(event);
+
+  function getSystemActionInfo(event: string): { label: string; category: string } {
+    const uiAction = uiActions.find(action => action.id === event);
+    if (uiAction) {
+      return {label: uiAction.label, category: uiAction.category};
+    }
+
+    if (['layout_swap', 'layout_switch', 'layout_cycle_forward', 'layout_cycle_backward'].includes(event)) {
+      return {
+        label: allowedEventKeybinds[event]?.label ?? event,
+        category: 'Layout'
+      };
+    }
+
+    if (event === 'fullscreen_toggle') {
+      return {
+        label: allowedEventKeybinds[event]?.label ?? event,
+        category: 'Window'
+      };
+    }
+
+    return {
+      label: allowedEventKeybinds[event]?.label ?? event,
+      category: 'System'
+    };
+  }
+
+  function getKeybindActionCategory(event: string, fallback: string): string {
+    if (event === 'send_session_action' || event === 'send_to_receiver') {
+      return 'Action';
+    }
+
+    if (['layout_swap', 'layout_switch', 'layout_cycle_forward', 'layout_cycle_backward'].includes(event)) {
+      return 'Layout';
+    }
+
+    if (event === 'fullscreen_toggle') {
+      return 'Window';
+    }
+
+    if (event === 'custom_event') {
+      return 'Custom';
+    }
+
+    return fallback;
+  }
+
+  function getKeybindEventDescription(event: string): string {
+    switch (event) {
+      case 'ui.toggle_quest_log':
+        return 'Show / Hide the Quest Log Panel.';
+      case 'fullscreen_toggle':
+        return 'Toggles Fullscreen Mode.';
+      case 'layout_swap':
+        return 'Switches between the two last used Layouts.';
+      case 'layout_cycle_forward':
+        return 'Cycles to the Next Layout.';
+      case 'layout_cycle_backward':
+        return 'Cycles to the Previous Layout.';
+      case 'send_session_action':
+        return 'Sends the Selected Action to the Selected Session.';
+      case 'send_to_receiver':
+        return 'Sends the Selected Key to the Active Receiver Session.';
+      case 'custom_event':
+        return 'Dispatches a Custom NeuzOS Event.';
+      default:
+        return 'No Additional Event Data Required.';
+    }
+  }
+
+  function getKeybindEventDataDescription(event: string): string | null {
+    switch (event) {
+      case 'layout_switch':
+        return 'Jump to a Specific Layout.';
+      case 'send_session_action':
+        return 'Choose the Session and Action for this Keybind.';
+      case 'send_to_receiver':
+        return 'Choose the Key sent to the Active Receiver Session.';
+      default:
+        return null;
+    }
+  }
+
+  function getAddableGlobalEventIds(): string[] {
+    const knownSystemEvents = systemActionEventIds.filter(event => {
+      return event.startsWith('ui.') || allowedEventKeybinds[event];
+    });
+    const regularEvents = Object.keys(allowedEventKeybinds).filter(event => !isSystemActionEvent(event));
+
+    return [...knownSystemEvents, ...regularEvents];
+  }
+
+  function canAddGlobalKeybind(event: string): boolean {
+    const existing = neuzosConfig.keyBinds.find(keyBind => keyBind.event === event);
+    if (event === 'layout_switch') {
+      return true;
+    }
+
+    if (isSystemActionEvent(event)) {
+      return !existing;
+    }
+
+    return !(allowedEventKeybinds[event]?.unique && existing);
+  }
+
+  function addGlobalKeybind(event: string) {
+    const argCount = allowedEventKeybinds[event]?.args?.length || 0;
+    neuzosConfig.keyBinds.push({
+      key: '',
+      event,
+      args: new Array(argCount).fill('')
+    });
+    addKeybindPopoverOpen = false;
+  }
 
   function parseKeybind(keybind: string): { modifier: string; key: string } {
     const parts = keybind.split("+");
@@ -71,6 +195,14 @@
   const electronApi = getElectronContext();
   const neuzosConfig = getContext<NeuzConfig>("neuzosConfig");
 
+  const systemActionKeybinds = $derived(
+    neuzosConfig.keyBinds.filter(keyBind => isSystemActionEvent(keyBind.event))
+  );
+
+  const regularGlobalKeybinds = $derived(
+    neuzosConfig.keyBinds.filter(keyBind => !isSystemActionEvent(keyBind.event))
+  );
+
   onMount(async () => {
     allowedEventKeybinds = await electronApi.invoke("config.get_available_event_keybinds");
     uiActions = await electronApi.invoke("config.get_available_ui_actions");
@@ -82,18 +214,12 @@
   let layoutSelectorStates: { [index: number]: boolean } = $state({});
   let sessionSelectorStates: { [index: number]: boolean } = $state({});
   let actionSelectorStates: { [index: number]: boolean } = $state({});
-  let uiActionComboboxStates: Array<{ open: boolean; modifierOpen: boolean }> = $state([]);
-  let uiActionConflictWarnings: { [actionId: string]: string } = $state({});
+  let systemActionConflictWarnings: { [index: number]: string } = $state({});
 
   $effect(() => {
     const neededLength = neuzosConfig.keyBinds.length;
     while (comboboxStates.length < neededLength) comboboxStates.push({open: false, modifierOpen: false});
     if (comboboxStates.length > neededLength) comboboxStates.length = neededLength;
-  });
-
-  $effect(() => {
-    while (uiActionComboboxStates.length < uiActions.length) uiActionComboboxStates.push({open: false, modifierOpen: false});
-    if (uiActionComboboxStates.length > uiActions.length) uiActionComboboxStates.length = uiActions.length;
   });
 
   function moveKeybindUp(index: number) {
@@ -116,6 +242,34 @@
       [states[index], states[index + 1]] = [states[index + 1], states[index]];
       comboboxStates = states;
     }
+  }
+
+  function moveSystemActionUp(keyBind: NeuzKeybind) {
+    const currentSystemIndex = systemActionKeybinds.indexOf(keyBind);
+    if (currentSystemIndex <= 0) return;
+
+    const previousSystemBind = systemActionKeybinds[currentSystemIndex - 1];
+    const currentIndex = neuzosConfig.keyBinds.indexOf(keyBind);
+    const previousIndex = neuzosConfig.keyBinds.indexOf(previousSystemBind);
+    if (currentIndex < 0 || previousIndex < 0) return;
+
+    const keybinds = [...neuzosConfig.keyBinds];
+    [keybinds[currentIndex], keybinds[previousIndex]] = [keybinds[previousIndex], keybinds[currentIndex]];
+    neuzosConfig.keyBinds = keybinds;
+  }
+
+  function moveSystemActionDown(keyBind: NeuzKeybind) {
+    const currentSystemIndex = systemActionKeybinds.indexOf(keyBind);
+    if (currentSystemIndex < 0 || currentSystemIndex >= systemActionKeybinds.length - 1) return;
+
+    const nextSystemBind = systemActionKeybinds[currentSystemIndex + 1];
+    const currentIndex = neuzosConfig.keyBinds.indexOf(keyBind);
+    const nextIndex = neuzosConfig.keyBinds.indexOf(nextSystemBind);
+    if (currentIndex < 0 || nextIndex < 0) return;
+
+    const keybinds = [...neuzosConfig.keyBinds];
+    [keybinds[currentIndex], keybinds[nextIndex]] = [keybinds[nextIndex], keybinds[currentIndex]];
+    neuzosConfig.keyBinds = keybinds;
   }
 
   // ── Profile management ───────────────────────────────────────────────────────
@@ -227,65 +381,47 @@
     profileAddKeybindPopovers[profile.id] = false;
   }
 
-  function getUiActionKeybind(actionId: string): NeuzKeybind | undefined {
-    const activeProfile = getActiveProfile();
-    return activeProfile?.keybinds.find(keyBind => keyBind.event === actionId);
-  }
+  function applySystemActionKeybind(keyBind: NeuzKeybind, keybind: string): boolean {
+    const keyBindIndex = neuzosConfig.keyBinds.indexOf(keyBind);
+    if (keyBindIndex < 0) return false;
 
-  function setUiActionKeybind(actionId: string, keybind: string) {
-    const activeProfile = getActiveProfile();
-    if (!activeProfile) return;
-
-    const existingIndex = activeProfile.keybinds.findIndex(keyBind => keyBind.event === actionId);
     if (!keybind) {
-      if (existingIndex !== -1) {
-        activeProfile.keybinds.splice(existingIndex, 1);
-      }
-      return;
-    }
-
-    if (existingIndex !== -1) {
-      activeProfile.keybinds[existingIndex].key = keybind;
-      return;
-    }
-
-    activeProfile.keybinds.push({key: keybind, event: actionId});
-  }
-
-  function applyUiActionKeybind(actionId: string, keybind: string): boolean {
-    if (!keybind) {
-      removeUiActionKeybind(actionId);
-      delete uiActionConflictWarnings[actionId];
+      removeSystemActionKeybind(keyBind);
+      delete systemActionConflictWarnings[keyBindIndex];
       return true;
     }
 
-    const conflictLabel = getUiActionConflict(actionId, keybind);
+    const conflictLabel = getSystemActionConflict(keyBind, keybind);
     if (conflictLabel) {
-      uiActionConflictWarnings[actionId] = conflictLabel;
+      systemActionConflictWarnings[keyBindIndex] = conflictLabel;
       return false;
     }
 
-    delete uiActionConflictWarnings[actionId];
-    setUiActionKeybind(actionId, keybind);
+    delete systemActionConflictWarnings[keyBindIndex];
+    keyBind.key = keybind;
     return true;
   }
 
-  function removeUiActionKeybind(actionId: string) {
-    delete uiActionConflictWarnings[actionId];
-    setUiActionKeybind(actionId, "");
+  function removeSystemActionKeybind(keyBind: NeuzKeybind) {
+    const keyBindIndex = neuzosConfig.keyBinds.indexOf(keyBind);
+    if (keyBindIndex < 0) return;
+
+    delete systemActionConflictWarnings[keyBindIndex];
+    neuzosConfig.keyBinds.splice(keyBindIndex, 1);
   }
 
-  function getUiActionConflict(actionId: string, keybind: string): string | null {
+  function getSystemActionConflict(currentKeyBind: NeuzKeybind, keybind: string): string | null {
     if (!keybind) return null;
 
-    const activeProfile = getActiveProfile();
-    const conflict = activeProfile?.keybinds.find(existingBind => {
-      return existingBind.event !== actionId && existingBind.key.toLowerCase() === keybind.toLowerCase();
+    const conflict = neuzosConfig.keyBinds.find(existingBind => {
+      return existingBind !== currentKeyBind && existingBind.key.toLowerCase() === keybind.toLowerCase();
     });
 
     if (!conflict) return null;
 
-    return uiActions.find(action => action.id === conflict.event)?.label ?? conflict.event;
+    return uiActions.find(action => action.id === conflict.event)?.label
+      ?? allowedEventKeybinds[conflict.event]?.label
+      ?? conflict.event;
   }
 
   function removeProfileKeybind(profile: NeuzKeyBindProfile, index: number) {
@@ -339,6 +475,10 @@
 
     <!-- ── Keybind Profiles ───────────────────────────────────────────────── -->
     <div class="w-full flex flex-col gap-3">
+      <div>
+        <h3 class="text-sm font-semibold">Profile Keybinds</h3>
+        <p class="text-xs text-muted-foreground mt-1">These Keybinds are only active while their assigned profile is active.</p>
+      </div>
       <div class="flex items-center gap-2">
         <Button variant="outline" size="sm" onclick={addProfile}>
           <Plus class="size-4 mr-2"/>
@@ -391,7 +531,7 @@
                       <span class="font-medium">{profile.name}</span>
                     {/if}
                     <span class="text-sm text-muted-foreground">
-                      {profile.keybinds.length} keybind{profile.keybinds.length !== 1 ? 's' : ''}
+                      {profile.keybinds.length} Keybind{profile.keybinds.length !== 1 ? 's' : ''}
                       {#if isActive}<span class="ml-1 text-primary font-semibold">· Active</span>{/if}
                     </span>
                   </div>
@@ -424,24 +564,24 @@
                 <div class="space-y-3">
                   {#if profile.keybinds.length > 0}
                     <div class="rounded-md border">
-                      <Table.Root>
+                      <Table.Root class="table-fixed min-w-[1040px]">
                         <Table.Header>
                           <Table.Row>
                             <Table.Head class="font-bold w-[60px]">Order</Table.Head>
-                            <Table.Head class="font-bold">Modifier</Table.Head>
-                            <Table.Head class="font-bold">Key</Table.Head>
-                            <Table.Head class="font-bold">Record</Table.Head>
+                            <Table.Head class="font-bold w-[220px]">Action</Table.Head>
+                            <Table.Head class="font-bold w-[460px]">Modifier + Key</Table.Head>
                             <Table.Head class="font-bold">Event</Table.Head>
-                            <Table.Head class="w-full"></Table.Head>
-                            <Table.Head></Table.Head>
+                            <Table.Head class="w-[56px]"></Table.Head>
                           </Table.Row>
                         </Table.Header>
                         <Table.Body>
                           {#each profile.keybinds as keyBind, index (index)}
-                            {@const eventInfo = allowedEventKeybinds[keyBind.event]}
-                            {@const parsed = parseKeybind(keyBind.key)}
-                            {@const state = profileStates[index] ?? {open: false, modifierOpen: false}}
-                            <Table.Row class="hover:bg-muted/50">
+                            {#if !isSystemActionEvent(keyBind.event)}
+                              {@const eventInfo = allowedEventKeybinds[keyBind.event]}
+                              {@const parsed = parseKeybind(keyBind.key)}
+                              {@const keyOnly = parsed.key}
+                              {@const state = profileStates[index] ?? {open: false, modifierOpen: false}}
+                              <Table.Row class="hover:bg-muted/50">
                               <Table.Cell>
                                 <div class="flex flex-col gap-0.5">
                                   <Button variant="outline" size="icon-xs" onclick={() => moveProfileKeybindUp(profile, index)} disabled={index === 0}>
@@ -452,73 +592,76 @@
                                   </Button>
                                 </div>
                               </Table.Cell>
-                              <!-- Modifier -->
-                              <Table.Cell>
-                                <Popover.Root bind:open={state.modifierOpen}>
-                                  <Popover.Trigger class="w-48 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                                    {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
-                                    <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
-                                    <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                                  </Popover.Trigger>
-                                  <Popover.Content class="w-[220px] p-0">
-                                    <Command.Root shouldFilter={true}>
-                                      <Command.Input placeholder="Search modifier..." class="h-10"/>
-                                      <Command.Empty>No modifier found.</Command.Empty>
-                                      <Command.List class="max-h-[320px]">
-                                        <Command.Group>
-                                          {#each modifierOptions as modifier}
-                                            <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { keyBind.key = buildKeybind(modifier.value, parsed.key); state.modifierOpen = false; }} class="font-medium py-2.5">
-                                              <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                              <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
-                                            </Command.Item>
-                                          {/each}
-                                        </Command.Group>
-                                      </Command.List>
-                                    </Command.Root>
-                                  </Popover.Content>
-                                </Popover.Root>
+                              <Table.Cell class="font-medium">
+                                <div class="flex flex-col gap-0.5">
+                                  <span>{eventInfo?.label}</span>
+                                  <span class="text-xs text-muted-foreground">{getKeybindActionCategory(keyBind.event, 'Profile')}</span>
+                                </div>
                               </Table.Cell>
-                              <!-- Key -->
                               <Table.Cell>
-                                {@const keyOnly = parsed.key}
-                                <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
-                                  <Popover.Trigger class="w-40 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                                    <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
-                                    <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                                  </Popover.Trigger>
-                                  <Popover.Content class="w-[220px] p-0">
-                                    <Command.Root shouldFilter={true}>
-                                      <Command.Input placeholder="Search key..." class="h-10"/>
-                                      <Command.Empty>No key found.</Command.Empty>
-                                      <Command.List class="max-h-[320px]">
-                                        <Command.Group>
-                                          {#each allowedKeys as key}
-                                            <Command.Item value={key} onSelect={() => { keyBind.key = buildKeybind(parsed.modifier, key); state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
-                                              <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                              <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
-                                            </Command.Item>
-                                          {/each}
-                                        </Command.Group>
-                                      </Command.List>
-                                    </Command.Root>
-                                  </Popover.Content>
-                                </Popover.Root>
+                                <div class="flex items-center gap-2">
+                                  <Popover.Root bind:open={state.modifierOpen}>
+                                    <Popover.Trigger class="w-36 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                                      {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
+                                      <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
+                                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                                    </Popover.Trigger>
+                                    <Popover.Content class="w-[220px] p-0">
+                                      <Command.Root shouldFilter={true}>
+                                        <Command.Input placeholder="Search modifier..." class="h-10"/>
+                                        <Command.Empty>No modifier found.</Command.Empty>
+                                        <Command.List class="max-h-[320px]">
+                                          <Command.Group>
+                                            {#each modifierOptions as modifier}
+                                              <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { keyBind.key = buildKeybind(modifier.value, parsed.key); state.modifierOpen = false; }} class="font-medium py-2.5">
+                                                <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                                <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
+                                              </Command.Item>
+                                            {/each}
+                                          </Command.Group>
+                                        </Command.List>
+                                      </Command.Root>
+                                    </Popover.Content>
+                                  </Popover.Root>
+                                  <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
+                                    <Popover.Trigger class="w-32 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                                      <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
+                                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                                    </Popover.Trigger>
+                                    <Popover.Content class="w-[220px] p-0">
+                                      <Command.Root shouldFilter={true}>
+                                        <Command.Input placeholder="Search key..." class="h-10"/>
+                                        <Command.Empty>No key found.</Command.Empty>
+                                        <Command.List class="max-h-[320px]">
+                                          <Command.Group>
+                                            {#each allowedKeys as key}
+                                              <Command.Item value={key} onSelect={() => { keyBind.key = buildKeybind(parsed.modifier, key); state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
+                                                <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                                <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
+                                              </Command.Item>
+                                            {/each}
+                                          </Command.Group>
+                                        </Command.List>
+                                      </Command.Root>
+                                    </Popover.Content>
+                                  </Popover.Root>
+                                  <KeyBinder
+                                    actionId={keyBind.event}
+                                    currentKey={keyBind.key}
+                                    onBind={(capturedKey) => { keyBind.key = capturedKey; return true; }}
+                                    onCancel={() => {}}
+                                  />
+                                </div>
                               </Table.Cell>
-                              <!-- Record (KeyBinder) -->
-                              <Table.Cell>
-                                <KeyBinder
-                                  actionId={keyBind.event}
-                                  currentKey={keyBind.key}
-                                  onBind={(capturedKey) => { keyBind.key = capturedKey; return true; }}
-                                  onCancel={() => {}}
-                                />
-                              </Table.Cell>
-                              <!-- Event label -->
-                              <Table.Cell class="text-sm text-muted-foreground">{eventInfo?.label}</Table.Cell>
                               <!-- Args -->
                               <Table.Cell>
                                 {#if eventInfo?.args?.length > 0}
-                                  <div class="flex flex-wrap items-start gap-2">
+                                  {@const eventDataDescription = getKeybindEventDataDescription(keyBind.event)}
+                                  <div class="flex flex-col gap-2">
+                                    {#if eventDataDescription}
+                                      <span class="text-xs text-muted-foreground">{eventDataDescription}</span>
+                                    {/if}
+                                    <div class="flex flex-wrap items-start gap-2">
                                     {#each eventInfo?.args ?? [] as arg, argIndex}
                                       {#if arg === 'layout_id'}
                                         {@const isOpen = (profileLayoutStates[profile.id]?.[index]) ?? false}
@@ -677,9 +820,10 @@
                                         </div>
                                       {/if}
                                     {/each}
+                                    </div>
                                   </div>
                                 {:else}
-                                  <i class="text-accent-foreground opacity-50">No extra data needed.</i>
+                                  <span class="text-xs text-muted-foreground">{getKeybindEventDescription(keyBind.event)}</span>
                                 {/if}
                               </Table.Cell>
                               <Table.Cell>
@@ -687,13 +831,12 @@
                                   <Trash2 class="size-4"/>
                                 </Button>
                               </Table.Cell>
-                            </Table.Row>
+                              </Table.Row>
+                            {/if}
                           {/each}
                         </Table.Body>
                       </Table.Root>
                     </div>
-                  {:else}
-                    <p class="text-sm text-muted-foreground italic">No keybinds yet. Add one below.</p>
                   {/if}
 
                   <!-- Add keybind to profile -->
@@ -711,7 +854,7 @@
                         <Command.List class="max-h-[320px]">
                           <Command.Group>
                             {#each Object.keys(allowedEventKeybinds) as event (event)}
-                              {#if !(allowedEventKeybinds[event]?.unique && profile.keybinds.find(kb => kb.event === event))}
+                              {#if !allowedEventKeybinds[event]?.unique && !isSystemActionEvent(event)}
                                 {@const eventInfo = allowedEventKeybinds[event]}
                                 <Command.Item value={event} keywords={[eventInfo?.label.toLowerCase()]} onSelect={() => addProfileKeybind(profile, event)} class="py-2">
                                   <span>{eventInfo?.label}</span>
@@ -731,30 +874,44 @@
       </div>
     </div>
 
-    {#if uiActions.length > 0}
-      <div class="w-full flex flex-col gap-3">
-        <div>
-          <h3 class="text-sm font-semibold">Interface Actions</h3>
-          <p class="text-xs text-muted-foreground mt-1">These bindings live in the active profile and use the same modifier + key editor.</p>
-        </div>
+    <div class="w-full border-t border-border"></div>
 
-        <Table.Root>
-          <Table.Header>
-            <Table.Row>
-              <Table.Head class="font-bold">Action</Table.Head>
-              <Table.Head class="font-bold">Modifier</Table.Head>
-              <Table.Head class="font-bold">Key</Table.Head>
-              <Table.Head class="font-bold">Record</Table.Head>
-              <Table.Head class="w-full"></Table.Head>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {#each uiActions as action, actionIndex (action.id)}
-              {@const bind = getUiActionKeybind(action.id)}
-              {@const parsed = parseKeybind(bind?.key ?? '')}
-              {@const state = uiActionComboboxStates[actionIndex] ?? {open: false, modifierOpen: false}}
-              {@const conflictLabel = uiActionConflictWarnings[action.id] ?? getUiActionConflict(action.id, bind?.key ?? '')}
+    <div class="w-full flex flex-col gap-3">
+      <div>
+        <h3 class="text-sm font-semibold">System Actions</h3>
+        <p class="text-xs text-muted-foreground mt-1">These system Keybinds interact with interface and window behavior. They are independent of profiles.</p>
+      </div>
+
+      <Table.Root class="table-fixed min-w-[1040px]">
+        <Table.Header>
+          <Table.Row>
+            <Table.Head class="font-bold w-[60px]">Order</Table.Head>
+            <Table.Head class="font-bold w-[220px]">Action</Table.Head>
+            <Table.Head class="font-bold w-[460px]">Modifier + Key</Table.Head>
+            <Table.Head class="font-bold">Event</Table.Head>
+            <Table.Head class="w-[56px]"></Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+            {#each systemActionKeybinds as keyBind, actionIndex (keyBind)}
+              {@const action = getSystemActionInfo(keyBind.event)}
+              {@const eventInfo = allowedEventKeybinds[keyBind.event]}
+              {@const parsed = parseKeybind(keyBind.key)}
+              {@const keyOnly = parsed.key}
+              {@const globalIndex = neuzosConfig.keyBinds.indexOf(keyBind)}
+              {@const state = comboboxStates[globalIndex] ?? {open: false, modifierOpen: false}}
+              {@const conflictLabel = systemActionConflictWarnings[globalIndex] ?? getSystemActionConflict(keyBind, keyBind.key)}
               <Table.Row>
+                <Table.Cell>
+                  <div class="flex flex-col gap-0.5">
+                    <Button variant="outline" size="icon-xs" onclick={() => moveSystemActionUp(keyBind)} disabled={actionIndex === 0}>
+                      <ChevronUp class="h-3 w-3"/>
+                    </Button>
+                    <Button variant="outline" size="icon-xs" onclick={() => moveSystemActionDown(keyBind)} disabled={actionIndex >= systemActionKeybinds.length - 1}>
+                      <ChevronDown class="h-3 w-3"/>
+                    </Button>
+                  </div>
+                </Table.Cell>
                 <Table.Cell class="font-medium">
                   <div class="flex flex-col gap-0.5">
                     <span>{action.label}</span>
@@ -762,73 +919,120 @@
                   </div>
                 </Table.Cell>
                 <Table.Cell>
-                  <Popover.Root bind:open={state.modifierOpen}>
-                    <Popover.Trigger class="w-48 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                      {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
-                      <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
-                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                    </Popover.Trigger>
-                    <Popover.Content class="w-[220px] p-0">
-                      <Command.Root shouldFilter={true}>
-                        <Command.Input placeholder="Search modifier..." class="h-10"/>
-                        <Command.Empty>No modifier found.</Command.Empty>
-                        <Command.List class="max-h-[320px]">
-                          <Command.Group>
-                            {#each modifierOptions as modifier}
-                              <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { if (applyUiActionKeybind(action.id, buildKeybind(modifier.value, parsed.key))) state.modifierOpen = false; }} class="font-medium py-2.5">
-                                <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
-                              </Command.Item>
-                            {/each}
-                          </Command.Group>
-                        </Command.List>
-                      </Command.Root>
-                    </Popover.Content>
-                  </Popover.Root>
+                  <div class="flex items-center gap-2">
+                    <Popover.Root bind:open={state.modifierOpen}>
+                      <Popover.Trigger class="w-36 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                        {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
+                        <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
+                        <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                      </Popover.Trigger>
+                      <Popover.Content class="w-[220px] p-0">
+                        <Command.Root shouldFilter={true}>
+                          <Command.Input placeholder="Search modifier..." class="h-10"/>
+                          <Command.Empty>No modifier found.</Command.Empty>
+                          <Command.List class="max-h-[320px]">
+                            <Command.Group>
+                              {#each modifierOptions as modifier}
+                                <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { if (applySystemActionKeybind(keyBind, buildKeybind(modifier.value, parsed.key))) state.modifierOpen = false; }} class="font-medium py-2.5">
+                                  <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                  <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
+                                </Command.Item>
+                              {/each}
+                            </Command.Group>
+                          </Command.List>
+                        </Command.Root>
+                      </Popover.Content>
+                    </Popover.Root>
+                    <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
+                      <Popover.Trigger class="w-32 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                        <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
+                        <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                      </Popover.Trigger>
+                      <Popover.Content class="w-[220px] p-0">
+                        <Command.Root shouldFilter={true}>
+                          <Command.Input placeholder="Search key..." class="h-10"/>
+                          <Command.Empty>No key found.</Command.Empty>
+                          <Command.List class="max-h-[320px]">
+                            <Command.Group>
+                              {#each allowedKeys as key}
+                                <Command.Item value={key} onSelect={() => { if (applySystemActionKeybind(keyBind, buildKeybind(parsed.modifier, key))) state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
+                                  <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                  <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
+                                </Command.Item>
+                              {/each}
+                            </Command.Group>
+                          </Command.List>
+                        </Command.Root>
+                      </Popover.Content>
+                    </Popover.Root>
+                    <div>
+                      <KeyBinder
+                        actionId={keyBind.event}
+                        currentKey={keyBind.key}
+                        conflictLabel={conflictLabel ?? undefined}
+                        onBind={(key) => applySystemActionKeybind(keyBind, key)}
+                        onCancel={() => { delete systemActionConflictWarnings[globalIndex]; }}
+                      />
+                      {#if keyBind.key.startsWith('Mouse') || keyBind.key.startsWith('Gamepad')}
+                        <p class="mt-1 text-xs text-muted-foreground">Fires only when neuzOS window has focus</p>
+                      {/if}
+                    </div>
+                  </div>
                 </Table.Cell>
                 <Table.Cell>
-                  {@const keyOnly = parsed.key}
-                  <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
-                    <Popover.Trigger class="w-40 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                      <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
-                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                    </Popover.Trigger>
-                    <Popover.Content class="w-[220px] p-0">
-                      <Command.Root shouldFilter={true}>
-                        <Command.Input placeholder="Search key..." class="h-10"/>
-                        <Command.Empty>No key found.</Command.Empty>
-                        <Command.List class="max-h-[320px]">
-                          <Command.Group>
-                            {#each allowedKeys as key}
-                              <Command.Item value={key} onSelect={() => { if (applyUiActionKeybind(action.id, buildKeybind(parsed.modifier, key))) state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
-                                <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
-                              </Command.Item>
-                            {/each}
-                          </Command.Group>
-                        </Command.List>
-                      </Command.Root>
-                    </Popover.Content>
-                  </Popover.Root>
-                </Table.Cell>
-                <Table.Cell>
-                  <KeyBinder
-                    actionId={action.id}
-                    currentKey={bind?.key ?? ''}
-                    conflictLabel={conflictLabel ?? undefined}
-                    onBind={(key) => applyUiActionKeybind(action.id, key)}
-                    onCancel={() => { delete uiActionConflictWarnings[action.id]; }}
-                  />
-                  {#if (bind?.key ?? '').startsWith('Mouse') || (bind?.key ?? '').startsWith('Gamepad')}
-                    <p class="mt-1 text-xs text-muted-foreground">Fires only when neuzOS window has focus</p>
+                  {#if eventInfo?.args?.length > 0}
+                    {@const eventDataDescription = getKeybindEventDataDescription(keyBind.event)}
+                    <div class="flex flex-col gap-2">
+                      {#if eventDataDescription}
+                        <span class="text-xs text-muted-foreground">{eventDataDescription}</span>
+                      {/if}
+                      <div class="flex flex-wrap items-start gap-2">
+                      {#each eventInfo?.args ?? [] as arg, argIndex}
+                        {#if arg === 'layout_id'}
+                          {@const isLayoutSelectorOpen = layoutSelectorStates[globalIndex] ?? false}
+                          {@const selectedLayout = neuzosConfig.layouts.find(layout => layout.id === keyBind.args?.[argIndex])}
+                          <div class="flex items-center gap-2">
+                            <span class="text-xs text-muted-foreground whitespace-nowrap">Layout:</span>
+                            <Popover.Root open={isLayoutSelectorOpen} onOpenChange={(open) => { layoutSelectorStates[globalIndex] = open; }}>
+                              <Popover.Trigger>
+                                <Button variant="outline" size="sm" class="h-9">
+                                  {#if selectedLayout}<img class="w-4 h-4 mr-2" src="icons/{selectedLayout.icon.slug}.png" alt=""/>{selectedLayout.label}{:else}Select Layout{/if}
+                                </Button>
+                              </Popover.Trigger>
+                              <Popover.Content class="w-[280px] p-0">
+                                <Command.Root shouldFilter={true}>
+                                  <Command.Input placeholder="Search layouts..." class="h-10"/>
+                                  <Command.Empty>No layout found.</Command.Empty>
+                                  <Command.List class="max-h-[320px]">
+                                    <Command.Group>
+                                      {#each neuzosConfig.layouts as layout}
+                                        <Command.Item value={layout.id} keywords={[layout.label.toLowerCase()]} onSelect={() => { if (!keyBind.args) keyBind.args = []; keyBind.args[argIndex] = layout.id; layoutSelectorStates[globalIndex] = false; }} class="py-2">
+                                          <img class="size-5 mr-2" src="icons/{layout.icon.slug}.png" alt=""/><span>{layout.label}</span>
+                                        </Command.Item>
+                                      {/each}
+                                    </Command.Group>
+                                  </Command.List>
+                                </Command.Root>
+                              </Popover.Content>
+                            </Popover.Root>
+                          </div>
+                        {:else}
+                          <div class="flex items-center gap-2">
+                            <span class="text-xs text-muted-foreground whitespace-nowrap">{arg}:</span>
+                            <input type="text" class="w-48 h-9 px-3 py-2 rounded-md text-sm border-2 border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2" placeholder="Enter {arg}..." bind:value={keyBind.args[argIndex]}/>
+                          </div>
+                        {/if}
+                      {/each}
+                      </div>
+                    </div>
+                  {:else}
+                    <span class="text-xs text-muted-foreground">{getKeybindEventDescription(keyBind.event)}</span>
                   {/if}
                 </Table.Cell>
                 <Table.Cell class="text-right">
-                  {#if bind}
-                    <Button variant="outline" size="sm" onclick={() => removeUiActionKeybind(action.id)}>
-                      <Trash2 class="size-4"/>
-                    </Button>
-                  {/if}
+                  <Button variant="outline" size="sm" onclick={() => removeSystemActionKeybind(keyBind)}>
+                    <Trash2 class="size-4"/>
+                  </Button>
                 </Table.Cell>
               </Table.Row>
               {#if conflictLabel}
@@ -839,10 +1043,9 @@
                 </Table.Row>
               {/if}
             {/each}
-          </Table.Body>
-        </Table.Root>
-      </div>
-    {/if}
+        </Table.Body>
+      </Table.Root>
+    </div>
 
     <div class="w-full border-t border-border"></div>
 
@@ -850,25 +1053,25 @@
     <div class="w-full flex flex-col gap-3">
       <div>
         <h3 class="text-sm font-semibold">Global Keybinds</h3>
-        <p class="text-xs text-muted-foreground mt-1">These keybinds are always active regardless of the selected profile.</p>
+        <p class="text-xs text-muted-foreground mt-1">These Keybinds are always active regardless of the selected profile.</p>
       </div>
-      <Table.Root>
+      {#if regularGlobalKeybinds.length > 0}
+      <Table.Root class="table-fixed min-w-[1040px]">
         <Table.Header>
           <Table.Row>
             <Table.Head class="font-bold w-[60px]">Order</Table.Head>
-            <Table.Head class="font-bold">Modifier</Table.Head>
-            <Table.Head class="font-bold">Key</Table.Head>
-                          <Table.Head class="font-bold">Record</Table.Head>
+            <Table.Head class="font-bold w-[220px]">Action</Table.Head>
+            <Table.Head class="font-bold w-[460px]">Modifier + Key</Table.Head>
             <Table.Head class="font-bold">Event</Table.Head>
-            <Table.Head class="w-full"></Table.Head>
-            <Table.Head class="font-bold"></Table.Head>
+            <Table.Head class="font-bold w-[56px]"></Table.Head>
           </Table.Row>
         </Table.Header>
         <Table.Body>
           {#each neuzosConfig.keyBinds as keyBind, index}
             {@const eventInfo = allowedEventKeybinds[keyBind.event]}
             {@const parsed = parseKeybind(keyBind.key)}
-            {#if comboboxStates[index]}
+            {@const keyOnly = parsed.key}
+            {#if !isSystemActionEvent(keyBind.event) && comboboxStates[index]}
               {@const state = comboboxStates[index]}
               <Table.Row>
                 <Table.Cell>
@@ -881,72 +1084,79 @@
                     </Button>
                   </div>
                 </Table.Cell>
+                <Table.Cell class="font-medium">
+                  <div class="flex flex-col gap-0.5">
+                    <span>{eventInfo?.label}</span>
+                    <span class="text-xs text-muted-foreground">{getKeybindActionCategory(keyBind.event, 'Global')}</span>
+                  </div>
+                </Table.Cell>
                 <Table.Cell>
                   {@const modifierState = comboboxStates[index]}
-                  <Popover.Root bind:open={modifierState.modifierOpen}>
-                    <Popover.Trigger class="w-48 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                      {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
-                      <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
-                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                    </Popover.Trigger>
-                    <Popover.Content class="w-[220px] p-0">
-                      <Command.Root shouldFilter={true}>
-                        <Command.Input placeholder="Search modifier..." class="h-10"/>
-                        <Command.Empty>No modifier found.</Command.Empty>
-                        <Command.List class="max-h-[320px]">
-                          <Command.Group>
-                            {#each modifierOptions as modifier}
-                              <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { keyBind.key = buildKeybind(modifier.value, parsed.key); modifierState.modifierOpen = false; }} class="font-medium py-2.5">
-                                <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
-                              </Command.Item>
-                            {/each}
-                          </Command.Group>
-                        </Command.List>
-                      </Command.Root>
-                    </Popover.Content>
-                  </Popover.Root>
+                  <div class="flex items-center gap-2">
+                    <Popover.Root bind:open={modifierState.modifierOpen}>
+                      <Popover.Trigger class="w-36 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                        {@const selectedMod = modifierOptions.find(m => m.value === parsed.modifier)?.label ?? 'None'}
+                        <span class="truncate {parsed.modifier ? 'text-foreground' : 'text-muted-foreground'}">{selectedMod}</span>
+                        <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                      </Popover.Trigger>
+                      <Popover.Content class="w-[220px] p-0">
+                        <Command.Root shouldFilter={true}>
+                          <Command.Input placeholder="Search modifier..." class="h-10"/>
+                          <Command.Empty>No modifier found.</Command.Empty>
+                          <Command.List class="max-h-[320px]">
+                            <Command.Group>
+                              {#each modifierOptions as modifier}
+                                <Command.Item value={modifier.value} keywords={[modifier.label.toLowerCase()]} onSelect={() => { keyBind.key = buildKeybind(modifier.value, parsed.key); modifierState.modifierOpen = false; }} class="font-medium py-2.5">
+                                  <Check class={parsed.modifier === modifier.value ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                  <span class={parsed.modifier === modifier.value ? "text-primary" : ""}>{modifier.label}</span>
+                                </Command.Item>
+                              {/each}
+                            </Command.Group>
+                          </Command.List>
+                        </Command.Root>
+                      </Popover.Content>
+                    </Popover.Root>
+                    <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
+                      <Popover.Trigger class="w-32 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
+                        <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
+                        <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
+                      </Popover.Trigger>
+                      <Popover.Content class="w-[220px] p-0">
+                        <Command.Root shouldFilter={true}>
+                          <Command.Input placeholder="Search key..." class="h-10"/>
+                          <Command.Empty>No key found.</Command.Empty>
+                          <Command.List class="max-h-[320px]">
+                            <Command.Group>
+                              {#each allowedKeys as key}
+                                <Command.Item value={key} onSelect={() => { keyBind.key = buildKeybind(parsed.modifier, key); state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
+                                  <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
+                                  <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
+                                </Command.Item>
+                              {/each}
+                            </Command.Group>
+                          </Command.List>
+                        </Command.Root>
+                      </Popover.Content>
+                    </Popover.Root>
+                    <KeyBinder
+                      actionId={keyBind.event}
+                      currentKey={keyBind.key}
+                      onBind={(key) => {
+                        keyBind.key = key;
+                        return true;
+                      }}
+                      onCancel={() => {}}
+                    />
+                  </div>
                 </Table.Cell>
-                <Table.Cell>
-                  {@const keyOnly = parsed.key}
-                  <Popover.Root open={state.open} onOpenChange={(open) => { state.open = open; }}>
-                    <Popover.Trigger class="w-40 h-9 px-3 py-2 inline-flex items-center justify-between gap-2 rounded-md text-sm font-mono font-semibold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm">
-                      <span class="truncate {keyOnly ? 'text-foreground uppercase' : 'text-muted-foreground font-sans font-normal lowercase'}">{keyOnly || "select key..."}</span>
-                      <ChevronsUpDown class="h-4 w-4 shrink-0 opacity-50"/>
-                    </Popover.Trigger>
-                    <Popover.Content class="w-[220px] p-0">
-                      <Command.Root shouldFilter={true}>
-                        <Command.Input placeholder="Search key..." class="h-10"/>
-                        <Command.Empty>No key found.</Command.Empty>
-                        <Command.List class="max-h-[320px]">
-                          <Command.Group>
-                            {#each allowedKeys as key}
-                              <Command.Item value={key} onSelect={() => { keyBind.key = buildKeybind(parsed.modifier, key); state.open = false; }} class="font-mono font-semibold uppercase py-2.5">
-                                <Check class={keyOnly === key ? "mr-2 h-4 w-4 text-primary" : "mr-2 h-4 w-4 opacity-0"}/>
-                                <span class={keyOnly === key ? "text-primary" : ""}>{key}</span>
-                              </Command.Item>
-                            {/each}
-                          </Command.Group>
-                        </Command.List>
-                      </Command.Root>
-                    </Popover.Content>
-                  </Popover.Root>
-                </Table.Cell>
-                <Table.Cell>
-                  <KeyBinder
-                    actionId={keyBind.event}
-                    currentKey={keyBind.key}
-                    onBind={(key) => {
-                      keyBind.key = key;
-                      return true;
-                    }}
-                    onCancel={() => {}}
-                  />
-                </Table.Cell>
-                <Table.Cell class="text-sm text-muted-foreground">{eventInfo?.label}</Table.Cell>
                 <Table.Cell>
                   {#if eventInfo?.args?.length > 0}
-                    <div class="flex flex-wrap items-start gap-2">
+                    {@const eventDataDescription = getKeybindEventDataDescription(keyBind.event)}
+                    <div class="flex flex-col gap-2">
+                      {#if eventDataDescription}
+                        <span class="text-xs text-muted-foreground">{eventDataDescription}</span>
+                      {/if}
+                      <div class="flex flex-wrap items-start gap-2">
                       {#each eventInfo?.args ?? [] as arg, argIndex}
                         {#if arg === 'layout_id'}
                           {@const isLayoutSelectorOpen = layoutSelectorStates[index] ?? false}
@@ -1105,12 +1315,13 @@
                           </div>
                         {/if}
                       {/each}
+                      </div>
                     </div>
                   {:else}
-                    <i class="text-accent-foreground opacity-50"> No extra data is needed for this event.</i>
+                    <span class="text-xs text-muted-foreground">{getKeybindEventDescription(keyBind.event)}</span>
                   {/if}
                 </Table.Cell>
-                <Table.Cell class="text-sm text-muted-foreground">
+                <Table.Cell class="text-right">
                   <Button variant="outline" size="sm" onclick={() => { neuzosConfig.keyBinds.splice(neuzosConfig.keyBinds.indexOf(keyBind), 1) }}>
                     <Trash2 class="size-4"/>
                   </Button>
@@ -1120,11 +1331,12 @@
           {/each}
         </Table.Body>
       </Table.Root>
+      {/if}
       <Popover.Root open={addKeybindPopoverOpen} onOpenChange={(open) => { addKeybindPopoverOpen = open; }}>
-        <Popover.Trigger>
+        <Popover.Trigger class="self-start">
           <Button variant="outline" size="sm">
             <Plus class="size-4 mr-2"/>
-            Add a Global Shortcut Keybind
+            Add Global Keybind
           </Button>
         </Popover.Trigger>
         <Popover.Content class="w-[320px] p-0">
@@ -1133,21 +1345,13 @@
             <Command.Empty>No event found.</Command.Empty>
             <Command.List class="max-h-[320px]">
               <Command.Group>
-                {#each Object.keys(allowedEventKeybinds) as event (event)}
-                  {#if !(allowedEventKeybinds[event]?.unique && neuzosConfig.keyBinds.find(keyBind => keyBind.event === event))}
-                    {@const eventInfo = allowedEventKeybinds[event]}
+                {#each getAddableGlobalEventIds() as event (event)}
+                  {#if canAddGlobalKeybind(event)}
+                    {@const eventInfo = getSystemActionInfo(event)}
                     <Command.Item
                       value={event}
                       keywords={[eventInfo?.label.toLowerCase()]}
-                      onSelect={() => {
-                        const argCount = eventInfo?.args?.length || 0;
-                        neuzosConfig.keyBinds.push({
-                          key: '',
-                          event: event,
-                          args: new Array(argCount).fill('')
-                        });
-                        addKeybindPopoverOpen = false;
-                      }}
+                      onSelect={() => addGlobalKeybind(event)}
                       class="py-2"
                     >
                       <span>{eventInfo?.label}</span>

--- a/src/renderer/src/components/SettingsWindow/Tabs/LayoutSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/LayoutSettings.svelte
@@ -290,7 +290,7 @@
                           {#each layoutIcons as icon}
                             <Command.Item
                               value={icon}
-                              keywords={[icon.replace('misc/', '').replace('levels/', '').replace(/_/g, ' ').toLowerCase()]}
+                              keywords={[icon.replace('misc/', '').replace('levels/', '').replace('jobs/', '').replace('pets/', '').replace(/_/g, ' ').toLowerCase()]}
                               onSelect={() => {
                                 layout.icon.slug = icon;
                                 iconPopoverStates[layout.id] = false;
@@ -299,7 +299,7 @@
                             >
                               <img class="size-6 mr-2" src="icons/{icon}.png" alt=""/>
                               <span
-                                class="text-xs truncate">{icon.replace('misc/', '').replace('levels/', '').replace('jobs/', '')}</span>
+                                class="text-xs truncate">{icon.replace('misc/', '').replace('levels/', '').replace('jobs/', '').replace('pets/', '')}</span>
                             </Command.Item>
                           {/each}
                         </Command.Group>

--- a/src/renderer/src/components/SettingsWindow/Tabs/SessionSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/SessionSettings.svelte
@@ -5,7 +5,6 @@
     ChevronUp,
     Copy,
     FileX,
-    HardDrive,
     Plus,
     Trash,
     Globe,
@@ -55,10 +54,6 @@
 
   const clearCache = (sessionId: string) => {
     neuzosBridge.sessions.clearCache(sessionId)
-  }
-
-  const clearStorage = (sessionId: string) => {
-    neuzosBridge.sessions.clearStorage(sessionId)
   }
 
   const clampZoom = (value: number) => Math.min(1.5, Math.max(0.5, Math.round(value * 20) / 20))
@@ -251,7 +246,6 @@
   }
 
   let clearCacheOpenModal: string | null = $state(null)
-  let clearStorageOpenModal: string | null = $state(null)
   let clearAllCacheOpenModal: boolean = $state(false)
   let deleteSessionModal: { sessionId: string; sessionLabel: string; isRunning: boolean } | null = $state(null)
   let deleteErrorModal: { sessionLabel: string; error: string } | null = $state(null)
@@ -602,38 +596,6 @@
                     clearCache(session.id)
                     clearCacheOpenModal = null
                   }}>Clear Cache
-                </AlertDialog.Action>
-              </AlertDialog.Footer>
-            </AlertDialog.Content>
-          </AlertDialog.Root>
-          <AlertDialog.Root open={clearStorageOpenModal === session.id} onOpenChange={(open) => {
-            clearStorageOpenModal = open ? session.id : null;
-          }}>
-            <Tooltip.Root>
-              <Tooltip.Trigger>
-                <AlertDialog.Trigger>
-                  <Button variant="outline" size="icon" class="h-8 w-8">
-                    <HardDrive class="h-4 w-4"/>
-                  </Button>
-                </AlertDialog.Trigger>
-              </Tooltip.Trigger>
-              <Tooltip.Content>Clear session data</Tooltip.Content>
-            </Tooltip.Root>
-            <AlertDialog.Content>
-              <AlertDialog.Header>
-                <AlertDialog.Title>Clear "{session.label}" session's data.</AlertDialog.Title>
-                <AlertDialog.Description>
-                  This action will still clear any session data for <b>"{session.label}"</b> even
-                  without saving your changes later on.
-                </AlertDialog.Description>
-              </AlertDialog.Header>
-              <AlertDialog.Footer>
-                <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-                <AlertDialog.Action
-                  onclick={() => {
-                    clearStorage(session.id)
-                    clearStorageOpenModal = null
-                  }}>Clear Data
                 </AlertDialog.Action>
               </AlertDialog.Footer>
             </AlertDialog.Content>

--- a/src/renderer/src/components/SettingsWindow/Tabs/SessionSettings.svelte
+++ b/src/renderer/src/components/SettingsWindow/Tabs/SessionSettings.svelte
@@ -865,20 +865,22 @@
             Clear All Cache
           </Button>
         </AlertDialog.Trigger>
-        <AlertDialog.Content>
+        <AlertDialog.Content class="max-h-[85vh] overflow-hidden">
           <AlertDialog.Header>
             <AlertDialog.Title>Clear all sessions' cache?</AlertDialog.Title>
             <AlertDialog.Description>
               This action will clear the cache for all sessions even without saving your changes later on.<br/><br/>
               <strong>Sessions that will be affected:</strong>
-              <ul class="mt-2 space-y-1 list-disc list-inside">
-                {#each neuzosConfig.sessions as session}
-                  <li class="text-sm">
-                    <span class="font-medium">{session.label}</span>
-                    <span class="text-muted-foreground"> (ID: {session.id})</span>
-                  </li>
-                {/each}
-              </ul>
+              <div class="mt-2 max-h-[40vh] overflow-y-auto rounded-md border border-border/60 bg-muted/20 p-2">
+                <ul class="space-y-1 list-disc list-inside">
+                  {#each neuzosConfig.sessions as session}
+                    <li class="text-sm">
+                      <span class="font-medium">{session.label}</span>
+                      <span class="text-muted-foreground"> (ID: {session.id})</span>
+                    </li>
+                  {/each}
+                </ul>
+              </div>
               <br/>
               Your session data will still be saved.
             </AlertDialog.Description>

--- a/src/renderer/src/components/Shared/KeyBinder.svelte
+++ b/src/renderer/src/components/Shared/KeyBinder.svelte
@@ -316,7 +316,7 @@
         <p class="text-sm font-semibold">{isRecording ? 'Listening…' : 'Record mode ready'}</p>
       </div>
       <p class="text-xs text-muted-foreground">
-        Press a key, Mouse 4/5, or middle click. Escape cancels.
+        Press a Key to record Keybind. Press Escape to Cancel.
       </p>
       {#if isRecording && !gamepadDetected}
         <p class="text-xs text-muted-foreground">No gamepad detected — keyboard and mouse capture still active</p>

--- a/src/renderer/src/components/Shared/KeyBinder.svelte
+++ b/src/renderer/src/components/Shared/KeyBinder.svelte
@@ -306,7 +306,7 @@
 
 <Popover.Root open={open} onOpenChange={handleOpenChange}>
   <Popover.Trigger class="h-9 px-3 inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-primary/50 shadow-sm whitespace-nowrap">
-    <span class="truncate {currentKey ? 'text-foreground' : 'text-muted-foreground'}">{currentKey || 'Click to Bind'}</span>
+    <span class="truncate text-foreground">Record Keybind</span>
   </Popover.Trigger>
 
   <Popover.Content class="w-80 space-y-4">

--- a/src/renderer/src/components/Shared/NeuzClient.svelte
+++ b/src/renderer/src/components/Shared/NeuzClient.svelte
@@ -5,7 +5,6 @@
   import type {WebviewTag} from 'electron'
   import Button from '../../lib/components/ui/button/button.svelte'
   import {neuzosBridge} from "$lib/core";
-  import {RadioTower} from '@lucide/svelte'
 
   const webviewPreloadPath: string = (window as any)._preloadPaths?.webview ?? '';
 
@@ -23,11 +22,6 @@
   let webview: WebviewTag | HTMLElement = $state()
   let muted: boolean = $state(false)
   const mainWindowState = getContext<MainWindowState>('mainWindowState')
-  const isReceiver = $derived(mainWindowState.config.syncReceiverSessionId === session.id)
-
-  function toggleReceiver() {
-    neuzosBridge.sessions.setSyncReceiver(isReceiver ? null : session.id)
-  }
 
   const ensureSessionState = () => {
     const sessionState = mainWindowState.sessionsLayoutsRef[session.id] ??= {
@@ -395,15 +389,6 @@ window.open = function(...args) {
     focus()
   }}
 >
-  <button
-    type="button"
-      class={`absolute top-2 right-2 z-50 rounded p-1.5 transition-opacity ${isReceiver ? 'opacity-100 bg-primary text-primary-foreground shadow-md' : 'opacity-0 bg-background/60 text-muted-foreground group-hover:opacity-60 hover:!opacity-100'}`}
-    onclick={toggleReceiver}
-    aria-pressed={isReceiver}
-    title={isReceiver ? 'Active Receiver — click to clear' : 'Set as Active Receiver'}
-  >
-    <RadioTower size={16} />
-  </button>
   {#if partition !== ''}
     {#if started}
       {#if src.startsWith('https://flyff.wemadeconnect.com') && !koreanLinkFixed}

--- a/src/renderer/src/components/Widgets/Builtin/ActionPad/DropdownItem.svelte
+++ b/src/renderer/src/components/Widgets/Builtin/ActionPad/DropdownItem.svelte
@@ -2,7 +2,7 @@
   import { getWidgetsContext } from '$lib/contexts/widgetsContext.svelte';
   import { getContext } from 'svelte';
   import { Button } from '$lib/components/ui/button';
-  import { Keyboard, Eye, EyeOff, X } from '@lucide/svelte';
+  import { SquareAsterisk, Eye, EyeOff, X } from '@lucide/svelte';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import type { MainWindowState } from '$lib/types';
 
@@ -50,7 +50,7 @@
 {#if allSessionsWithActions.length > 0}
   <DropdownMenu.Sub>
     <DropdownMenu.SubTrigger>
-      <Keyboard class="h-4 w-4 mr-2" />
+      <SquareAsterisk class="h-4 w-4 mr-2" />
       <span>Action Pads</span>
     </DropdownMenu.SubTrigger>
     <DropdownMenu.SubContent class="min-w-44">

--- a/src/renderer/src/components/Widgets/Builtin/FloatingSession/DropdownItem.svelte
+++ b/src/renderer/src/components/Widgets/Builtin/FloatingSession/DropdownItem.svelte
@@ -2,10 +2,11 @@
   import { getWidgetsContext } from '$lib/contexts/widgetsContext.svelte';
   import { getContext } from 'svelte';
   import { Button } from '$lib/components/ui/button';
-  import { PictureInPicture2, Eye, EyeOff, X, RotateCcw } from '@lucide/svelte';
+  import { PictureInPicture2, Eye, EyeOff, X, RotateCcw, RadioTower, Check } from '@lucide/svelte';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import { toast } from 'svelte-sonner';
   import type { MainWindowState } from '$lib/types';
+  import { neuzosBridge } from '$lib/core';
 
   const FLOATING_SESSION_WIDGET_TYPE = 'widget.builtin.floating_session';
 
@@ -42,6 +43,16 @@
         description: 'Floating session position has been reset'
       });
     }
+  }
+
+  function isActiveReceiver(sessionId: string) {
+    return mainWindowState.config.syncReceiverSessionId === sessionId;
+  }
+
+  function toggleActiveReceiver(sessionId: string) {
+    const nextReceiverId = isActiveReceiver(sessionId) ? null : sessionId;
+    mainWindowState.config.syncReceiverSessionId = nextReceiverId;
+    neuzosBridge.sessions.setSyncReceiver(nextReceiverId);
   }
 
   const floatableSessions = $derived(
@@ -135,6 +146,33 @@
               <DropdownMenu.Item onclick={() => resetPosition(widget.data?.sessionId)}>
                 <img class="w-4 h-4 mr-2" src="icons/{sessionInfo?.icon || 'misc/browser'}.png" alt="" />
                 <span>{sessionInfo?.label || 'Unknown Session'}</span>
+              </DropdownMenu.Item>
+            {/each}
+          </DropdownMenu.SubContent>
+        </DropdownMenu.Sub>
+      {/if}
+
+      {#if floatableSessions.length > 0}
+        {#if widgets.length === 0}
+          <DropdownMenu.Separator />
+        {/if}
+        <DropdownMenu.Sub>
+          <DropdownMenu.SubTrigger class="cursor-pointer">
+            <RadioTower class="h-3 w-3 mr-2" />
+            <span>Active Receiver</span>
+          </DropdownMenu.SubTrigger>
+          <DropdownMenu.SubContent>
+            {#each floatableSessions as sessionInfo}
+              <DropdownMenu.Item onclick={() => toggleActiveReceiver(sessionInfo.id)}>
+                <div class="flex w-full items-center justify-between gap-4">
+                  <div class="flex items-center gap-2">
+                    <img class="w-4 h-4" src="icons/{sessionInfo.icon}.png" alt="" />
+                    <span>{sessionInfo.label}</span>
+                  </div>
+                  {#if isActiveReceiver(sessionInfo.id)}
+                    <Check class="h-4 w-4" />
+                  {/if}
+                </div>
               </DropdownMenu.Item>
             {/each}
           </DropdownMenu.SubContent>

--- a/src/renderer/src/components/Widgets/Builtin/FloatingSession/DropdownItem.svelte
+++ b/src/renderer/src/components/Widgets/Builtin/FloatingSession/DropdownItem.svelte
@@ -2,7 +2,7 @@
   import { getWidgetsContext } from '$lib/contexts/widgetsContext.svelte';
   import { getContext } from 'svelte';
   import { Button } from '$lib/components/ui/button';
-  import { Globe, Eye, EyeOff, X, RotateCcw } from '@lucide/svelte';
+  import { PictureInPicture2, Eye, EyeOff, X, RotateCcw } from '@lucide/svelte';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import { toast } from 'svelte-sonner';
   import type { MainWindowState } from '$lib/types';
@@ -65,7 +65,7 @@
 {#if floatableSessions.length > 0 || widgets.length > 0}
   <DropdownMenu.Sub>
     <DropdownMenu.SubTrigger>
-      <Globe class="h-4 w-4 mr-2" />
+      <PictureInPicture2 class="h-4 w-4 mr-2" />
       <span>Floating Sessions</span>
     </DropdownMenu.SubTrigger>
     <DropdownMenu.SubContent class="min-w-44 overflow-visible">

--- a/src/renderer/src/components/Widgets/Builtin/FloatingSession/Widget.svelte
+++ b/src/renderer/src/components/Widgets/Builtin/FloatingSession/Widget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import FloatingWindow from '../../../Shared/FloatingWindow.svelte';
   import NeuzClient from '../../../Shared/NeuzClient.svelte';
-  import { Globe } from '@lucide/svelte';
+  import { Globe, RadioTower } from '@lucide/svelte';
   import { getContext } from 'svelte';
   import { getWidgetsContext } from '$lib/contexts/widgetsContext.svelte';
   import type { MainWindowState } from '$lib/types';
@@ -25,6 +25,7 @@
   const sessionLabel = $derived(session?.label || 'Unknown Session');
   const sessionIcon = $derived(session?.icon?.slug || 'misc/browser');
   const layoutId = $derived(`floating-session-${sessionId || 'unknown'}`);
+  const isReceiver = $derived(sessionId !== undefined && mainWindowState.config.syncReceiverSessionId === sessionId);
 
   function handleClientUpdate(_sessionId: string) {
     // Floating widget does not need to update outer state on client events.
@@ -59,6 +60,9 @@
       <div class="flex items-center gap-2 min-w-0">
         <img class="w-4 h-4 shrink-0" src="icons/{sessionIcon}.png" alt="" />
         <span class="truncate">{sessionLabel}</span>
+        {#if isReceiver}
+          <RadioTower class="h-3.5 w-3.5 shrink-0 text-primary" />
+        {/if}
       </div>
     {/snippet}
 

--- a/src/renderer/src/components/Widgets/Builtin/MiniBrowser/DropdownItem.svelte
+++ b/src/renderer/src/components/Widgets/Builtin/MiniBrowser/DropdownItem.svelte
@@ -41,7 +41,7 @@
   <DropdownMenu.SubContent>
     <DropdownMenu.Item onclick={createWidget}>
       <Plus class="h-4 w-4 mr-2" />
-      <span>New browser</span>
+      <span>New Browser</span>
     </DropdownMenu.Item>
 
     <!-- Show active browser instances -->

--- a/src/renderer/src/components/Widgets/Core/WidgetsDropdownContent.svelte
+++ b/src/renderer/src/components/Widgets/Core/WidgetsDropdownContent.svelte
@@ -23,7 +23,7 @@
 {#if widgetsContext.widgets.length === 0}
   <DropdownMenu.Separator />
   <div class="px-2 py-1.5 text-xs text-muted-foreground text-center">
-    No active widgets
+    No active Widgets
   </div>
 {/if}
 


### PR DESCRIPTION
# Summary

This pull request includes several UI improvements, keybind system changes, bug and small layout fixes.

# Changes

Added scrolling to the Clear All Cache dialog to prevent overflow in small Settings windows.
Removed the Clear Session Data button from Settings → Sessions → Actions Column.
Fixed unwanted bottom and side scrollbars when the Quest Log sidebar is active.
Set the Main Window and Session Window to start maximized by default on first use.
Fixed Session Groups so they also appear correctly in Main Window Mode.
Added Cycle Layout Forward and Cycle Layout Backward keybind actions.
Cleaned up layout icon dropdown labels by removing subfolder prefixes like pets/....
Added the Action Pins icon to the top Mainbar when action pins exist.
Updated the KeyBinder recording instruction text.
Updated widget icons and fixed dropdown labels.
Moved Active Receiver selection into dropdown menus and added indicators for Mainbar layouts and Floating Sessions.

# Keybind Tab / System Actions

The Keybind settings tab was reworked with a new dedicated System Actions section.

Included changes:

Added a dedicated System Actions section.
Moved selected keybinds out of profile keybinds.
Added migration for existing profile keybinds into global/system keybinds.
Allowed Switch to Layout to be added multiple times.
Reworked table layout and spacing.
Added event and event data descriptions.
Standardized the Record Keybind button.
Adjusted empty states and global dropdown behavior.
Improved table stability for small window sizes.

# Notes

The changes are intended to improve Settings usability, reduce UI overflow issues, and better separate global/system keybinds from profile-specific keybinds.